### PR TITLE
Fix/update default names according validation rules

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -14,7 +14,7 @@
 		"dbVendor": "CouchbaseV7Plus"
 	},
 	"container": {
-		"name": "New scope",
+		"name": "New_scope",
 		"bucketType": "Couchbase",
 		"ramQuota": 100,
 		"cacheMetadata": "Value ejection",
@@ -26,7 +26,7 @@
 		"storageEngine": "Couchstore"
 	},
 	"collection": {
-		"collectionName": "New collection",
+		"collectionName": "New_collection",
 		"indexes": []
 	},
 	"field": {


### PR DESCRIPTION
[https://hackolade.atlassian.net/browse/HCK-3428](https://hackolade.atlassian.net/browse/HCK-3428)
- Scope and collection names cannot contain spaces. default names corrected according to validation rules