### PR TITLE
Bump plugin version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "CouchbaseV7Plus",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "versionDate": "2024-03-08",
     "author": "hackolade",
     "engines": {


### PR DESCRIPTION
## Content:

Bump manually the next plugin release version due to the failed automation process. 