### PR TITLE
HCK-5104: Fix invalid multiple types conversion on RE

### DIFF
--- a/reverse_engineering/helpers/queryHelper.js
+++ b/reverse_engineering/helpers/queryHelper.js
@@ -3,7 +3,7 @@
  * @returns {string}
  */
 const getInferCollectionDocumentsQuery = ({ bucketName, scopeName, collectionName, limit }) => {
-	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":3};`;
+	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":${limit}};`;
 };
 
 /**

--- a/reverse_engineering/helpers/queryHelper.js
+++ b/reverse_engineering/helpers/queryHelper.js
@@ -3,7 +3,7 @@
  * @returns {string}
  */
 const getInferCollectionDocumentsQuery = ({ bucketName, scopeName, collectionName, limit }) => {
-	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":${limit}};`;
+	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":3};`;
 };
 
 /**


### PR DESCRIPTION
[HCK-5104: Invalid multiple types conversion on RE](https://hackolade.atlassian.net/browse/HCK-5104)

**Parse multiple types after INFER result:**

Multiple types are wrapped into the array, so the type of such data should be checked. If the sample has an 'array' type we return it as it is.

![Screenshot 2024-04-03 164629](https://github.com/hackolade/CouchbaseV7Plus/assets/17798340/5be16799-1d29-425e-b5a4-6cb9a7faf553)