### PR TITLE
HCK-5214: show correct required status for collections without Primary Indexes

### DIFF
--- a/reverse_engineering/helpers/queryHelper.js
+++ b/reverse_engineering/helpers/queryHelper.js
@@ -3,7 +3,7 @@
  * @returns {string}
  */
 const getInferCollectionDocumentsQuery = ({ bucketName, scopeName, collectionName, limit }) => {
-	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":3};`;
+	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":${limit}};`;
 };
 
 /**

--- a/reverse_engineering/helpers/queryHelper.js
+++ b/reverse_engineering/helpers/queryHelper.js
@@ -1,9 +1,11 @@
+const { NUM_SAMPLE_VALUES } = require('../../shared/constants');
+
 /**
  * @param {{ bucketName: string; scopeName: string; collectionName: string; limit: number }} param0
  * @returns {string}
  */
 const getInferCollectionDocumentsQuery = ({ bucketName, scopeName, collectionName, limit }) => {
-	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":3};`;
+	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":${NUM_SAMPLE_VALUES}};`;
 };
 
 /**

--- a/reverse_engineering/helpers/queryHelper.js
+++ b/reverse_engineering/helpers/queryHelper.js
@@ -3,7 +3,7 @@
  * @returns {string}
  */
 const getInferCollectionDocumentsQuery = ({ bucketName, scopeName, collectionName, limit }) => {
-	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":${limit}};`;
+	return `INFER \`${bucketName}\`.\`${scopeName}\`.\`${collectionName}\` WITH {"sample_size":${limit}, "num_sample_values":3};`;
 };
 
 /**

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -50,6 +50,8 @@ const DEFAULT_KEY_NAME = '<key>';
 const DEFAULT_LIMIT = 1000;
 const DEFAULT_NAME = '_default';
 
+const NUM_SAMPLE_VALUES = 3;
+
 const COUCHBASE_DEFAULT_KV_CONNECTION_PORT = 11210;
 
 const DISABLED_TOOLTIP = 'Something went wrong. Please, check logs for more details';
@@ -66,6 +68,7 @@ module.exports = {
 	DEFAULT_KEY_NAME,
 	DEFAULT_LIMIT,
 	DEFAULT_NAME,
+	NUM_SAMPLE_VALUES,
 	DISABLED_TOOLTIP,
 	GET_META_REGEXP,
 	GET_NODES_REGEXP,

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -105,6 +105,13 @@ type DbCollectionData = {
 	entityLevel: object;
 }
 
+type InferenceProperty = {
+	"#docs": number;
+	"%docs": number;
+	samples?: Array<any>;
+	type: string | Array<string>
+}
+
 export {
 	App,
 	AppLogger,
@@ -124,4 +131,5 @@ export {
 	RecordSamplingSettings,
 	Scope,
 	UUID,
+	InferenceProperty,
 };


### PR DESCRIPTION
[[HCK-5214] CouchbaseV7Plus RE: required status is not correct for all fields](https://hackolade.atlassian.net/browse/HCK-5214)

All documents should be filled with data to avoid nullable values in the list. The current implementation poses a risk of generating null values if only one sample value is available across all documents.

[HCK-5214]: https://hackolade.atlassian.net/browse/HCK-5214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ