### PR TITLE
HCK-5352: couchbase collection indexes should be FEd in full and extended json schema

### DIFF
--- a/jsonSchemaProperties.json
+++ b/jsonSchemaProperties.json
@@ -1,4 +1,4 @@
 {
-	"unneededFieldProps": ["collectionName", "name", "users", "indexes", "collectionUsers", "additionalProperties"],
+	"unneededFieldProps": ["collectionName", "name", "users", "collectionUsers", "additionalProperties"],
 	"removeIfPropsNegative": ["partitionKey", "sortKey"]
 }


### PR DESCRIPTION
Removed the `indexes` property from the list of filtered  JSON schema properties