### PR TITLE
HCK-9245: `UPSERT` same keys

### DIFF
--- a/forward_engineering/services/applyToInstanceService.js
+++ b/forward_engineering/services/applyToInstanceService.js
@@ -22,14 +22,29 @@ const { COUCHBASE_ERROR_CODE, ERROR_SIMPLE_TYPE } = require('../../shared/consta
 const MAX_APPLY_ATTEMPTS = 5;
 const DEFAULT_START_DELAY = 1000;
 
+const scriptReducer = (scripts, script) => {
+	let adjusted = script.trim();
+	if (adjusted.startsWith('*/')) {
+		adjusted = adjusted.slice(2, adjusted.length);
+	}
+
+	if (adjusted) {
+		scripts.push(adjusted);
+	}
+
+	return scripts;
+};
+
 /**
  *
- * @param {{bucketName: string, script: string, cluster: object, logger: object, callback: function}} param
+ * @param {{bucketName: string, script: string, cluster: object, logger: object, callback: function}} param0
  * @returns {boolean}
  */
 const applyScript = async ({ bucketName, script, cluster, logger, callback }) => {
-	const scripts = script.split(';\n').map(trim).filter(Boolean);
+	const scripts = script.split(';\n').reduce(scriptReducer, []);
+
 	const maxNumberStatements = scripts.length;
+
 	const errorCodesToEarlyExit = new Set([
 		COUCHBASE_ERROR_CODE.collectionAlreadyExists,
 		COUCHBASE_ERROR_CODE.scopeAlreadyExists,
@@ -50,6 +65,10 @@ const applyScript = async ({ bucketName, script, cluster, logger, callback }) =>
 						err.type = ERROR_SIMPLE_TYPE;
 						return false;
 					}
+					if (errorCode === COUCHBASE_ERROR_CODE.parseSyntaxError && isCommentedStatement({ error: err })) {
+						err.skipError = true;
+						return false;
+					}
 
 					logApplyScriptAttempt({ attemptNumber, bucketName, logger });
 					return true;
@@ -68,7 +87,7 @@ const applyScript = async ({ bucketName, script, cluster, logger, callback }) =>
 					logger.progress(getApplyingScriptPercentMessage(applyingProgress));
 				}
 			} catch (err) {
-				if (isIndexAlreadyCreatedError(err)) {
+				if (isIndexAlreadyCreatedError(err) || err.skipError) {
 					logger.info(COUCHBASE_APPLY_TO_INSTANCE_SKIPPED_ERROR);
 				} else {
 					throw err;
@@ -108,7 +127,16 @@ const isIndexAlreadyCreatedError = err => {
 
 /**
  *
- * @param {{attemptNumber: number, bucketName: string, logger: object}} param
+ * @param {{error: object }} param0
+ * @returns {boolean}
+ */
+const isCommentedStatement = ({ error }) => {
+	return error.cause?.statement?.trim().startsWith('/*');
+};
+
+/**
+ *
+ * @param {{attemptNumber: number, bucketName: string, logger: object}} param0
  * @returns {void}
  */
 const logApplyScriptAttempt = ({ attemptNumber, bucketName, logger }) => {

--- a/forward_engineering/services/applyToInstanceService.js
+++ b/forward_engineering/services/applyToInstanceService.js
@@ -17,7 +17,7 @@ const {
 	getApplyingScriptToBucketWithAttemptNumberMessage,
 	getApplyingScriptMessage,
 } = require('../../shared/enums/dynamicMessages');
-const { COUCHBASE_ERROR_CODE } = require('../../shared/constants');
+const { COUCHBASE_ERROR_CODE, ERROR_SIMPLE_TYPE } = require('../../shared/constants');
 
 const MAX_APPLY_ATTEMPTS = 5;
 const DEFAULT_START_DELAY = 1000;
@@ -30,6 +30,11 @@ const DEFAULT_START_DELAY = 1000;
 const applyScript = async ({ bucketName, script, cluster, logger, callback }) => {
 	const scripts = script.split(';\n').map(trim).filter(Boolean);
 	const maxNumberStatements = scripts.length;
+	const errorCodesToEarlyExit = new Set([
+		COUCHBASE_ERROR_CODE.collectionAlreadyExists,
+		COUCHBASE_ERROR_CODE.scopeAlreadyExists,
+	]);
+
 	let previousApplyingProgress = 0;
 
 	async.eachOfSeries(
@@ -37,14 +42,25 @@ const applyScript = async ({ bucketName, script, cluster, logger, callback }) =>
 		async (script, index) => {
 			logger.info(APPLY_QUERY);
 			try {
-				await backOff(async () => cluster.query(script), {
-					numOfAttempts: MAX_APPLY_ATTEMPTS,
-					retry: (err, attemptNumber) => {
-						logApplyScriptAttempt({ attemptNumber, bucketName, logger });
-						return true;
-					},
+				const runQuery = () => cluster.query(script);
+
+				const retry = (err, attemptNumber) => {
+					const errorCode = clusterHelper.getErrorCode({ error: err });
+					if (errorCodesToEarlyExit.has(errorCode)) {
+						err.type = ERROR_SIMPLE_TYPE;
+						return false;
+					}
+
+					logApplyScriptAttempt({ attemptNumber, bucketName, logger });
+					return true;
+				};
+
+				await backOff(runQuery, {
 					startingDelay: DEFAULT_START_DELAY,
+					numOfAttempts: MAX_APPLY_ATTEMPTS,
+					retry,
 				});
+
 				const appliedStatements = index + 1;
 				const applyingProgress = Math.round((appliedStatements / maxNumberStatements) * 100);
 				if (applyingProgress - previousApplyingProgress >= 5) {
@@ -82,7 +98,12 @@ const isIndexAlreadyCreatedError = err => {
 	const errorCode = clusterHelper.getErrorCode({ error: err });
 	const errorMessage = clusterHelper.getErrorMessage({ error: err });
 
-	return errorCode === COUCHBASE_ERROR_CODE.indexAlreadyCreated || errorMessage.includes('already exist');
+	const existingIndexRelatedErrorCodes = [
+		COUCHBASE_ERROR_CODE.internalError,
+		COUCHBASE_ERROR_CODE.indexAlreadyCreated,
+	];
+
+	return existingIndexRelatedErrorCodes.includes(errorCode) && errorMessage.includes('already exist');
 };
 
 /**

--- a/forward_engineering/services/statements/indexesStatements.js
+++ b/forward_engineering/services/statements/indexesStatements.js
@@ -14,20 +14,21 @@ const getIndexesScript = ({ namespace, bucketName, scopeName, collectionName, in
 	const indexesKeysWithCorrespondingPropertiesNames = collectionIndexes.map(index =>
 		injectKeysNamesIntoIndexKeys({ index, keyIdToName }),
 	);
+	const statements = indexesKeysWithCorrespondingPropertiesNames.map(index => {
+		const indexData = {
+			...index,
+			namespace,
+			bucketName,
+			scopeName,
+			collectionName,
+		};
+		const indexStatement = getIndexScript(indexData);
+
+		return indexData.isActivated ? indexStatement : commentStatement(indexStatement);
+	});
 
 	return joinStatements({
-		statements: indexesKeysWithCorrespondingPropertiesNames.map(index => {
-			const indexData = {
-				...index,
-				namespace,
-				bucketName,
-				scopeName,
-				collectionName,
-			};
-			const indexStatement = getIndexScript(indexData);
-
-			return indexData.isActivated ? indexStatement : commentStatement(indexStatement);
-		}),
+		statements,
 		separator: '\n\n',
 	});
 };
@@ -82,12 +83,16 @@ const wrapCreateIndexStatementWithIfNotExistsClause = ({ ifNotExists, createStat
  * @returns {{script: string, canHaveIndex: boolean}}
  */
 const getKeys = index => {
+	const rawIndex = { script: '', canHaveIndex: true };
+
 	switch (index.indxType) {
 		case INDEX_TYPE.primary:
-			return { script: '', canHaveIndex: true };
+			return rawIndex;
 		case INDEX_TYPE.secondary: {
 			const keys = index.indxKey?.map(key => ({ ...key, name: wrapWithBackticks(key.name) }));
-
+			if (!keys) {
+				return { script: '', canHaveIndex: false };
+			}
 			const keysNames = joinStatements({
 				statements: keys
 					.map(key => joinStatements({ statements: filter([key.name, getOrder(key.type)]), separator: ' ' }))
@@ -102,7 +107,7 @@ const getKeys = index => {
 		case INDEX_TYPE.metadata:
 			return { script: `(${index.metadataExpr})`, canHaveIndex: true };
 		default:
-			return { script: '', canHaveIndex: true };
+			return rawIndex;
 	}
 };
 

--- a/forward_engineering/services/statements/insertStatements.js
+++ b/forward_engineering/services/statements/insertStatements.js
@@ -26,7 +26,7 @@ const getInsertScripts = ({ jsonData, collections = [] }) => {
  * @param {jsonData: object, collection: object} param0
  * @returns {string}
  */
-const getInsertScriptForCollection = ({ jsonData, collection }) => {
+const getInsertScriptForCollection = ({ jsonData, collection, useUpsert = true }) => {
 	if (collection.isActivated === false) {
 		return '';
 	}
@@ -40,11 +40,13 @@ const getInsertScriptForCollection = ({ jsonData, collection }) => {
 	const parseJsonData = JSON.parse(jsonData);
 	const sampleValue = collection?.properties?.[keyPropertyName]?.sample;
 	const keySample = isKeyGeneratedWithFakerFunction ? parseJsonData[keyPropertyName] : sampleValue;
-	const { [keyPropertyName]: keyProperty, ...jsonDataBody } = parseJsonData;
+	const { [keyPropertyName]: _keyProperty, ...jsonDataBody } = parseJsonData;
 	const pkSample = getPrimaryKeySampleByStructure({ collection, jsonData: parseJsonData });
 	const sampledKey = pkSample || keySample || uuid.v4();
+	const values = JSON.stringify(jsonDataBody, null, '\t');
+	const mutationClause = useUpsert ? 'UPSERT' : 'INSERT';
 
-	return `INSERT INTO ${insertionPath} (KEY, VALUE)\n\tVALUES("${sampledKey}",${JSON.stringify(jsonDataBody, null, '\t')});`;
+	return `${mutationClause} INTO ${insertionPath} (KEY, VALUE)\n\tVALUES("${sampledKey}",${values});`;
 };
 
 module.exports = {

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -19,15 +19,18 @@ const COUCHBASE_HOST_PREFIX = {
  */
 const COUCHBASE_ERROR_CODE = {
 	bucketIsEmpty: 0,
-	primaryIndexDoesNotExist: 4000,
-	n1qlMethodsAreNotSupported: 19,
-	userDoesNotHaveAccessToPrivilegeCluster: 13014,
-	parseSyntaxError: 3000,
-	inferMethodIsNotSupport: 16003,
-	collectionDoesNotExist: 12003,
-	indexAlreadyCreated: 4300,
-	duplicateDocumentKey: 12009,
 	authorizationFailure: 6,
+	n1qlMethodsAreNotSupported: 19,
+	parseSyntaxError: 3000,
+	primaryIndexDoesNotExist: 4000,
+	indexAlreadyCreated: 4300,
+	internalError: 5000,
+	collectionDoesNotExist: 12003,
+	duplicateDocumentKey: 12009,
+	scopeAlreadyExists: 12025,
+	collectionAlreadyExists: 12027,
+	userDoesNotHaveAccessToPrivilegeCluster: 13014,
+	inferMethodIsNotSupport: 16003,
 };
 
 /**
@@ -70,6 +73,8 @@ const PK_SEGMENT_TYPE = {
 	separator: 'separator',
 };
 
+const ERROR_SIMPLE_TYPE = 'simpleError';
+
 module.exports = {
 	AUTH_TYPE,
 	COUCHBASE_ERROR_CODE,
@@ -86,4 +91,5 @@ module.exports = {
 	HOSTING,
 	STATUS,
 	PK_SEGMENT_TYPE,
+	ERROR_SIMPLE_TYPE,
 };

--- a/shared/helpers/clusterHelper.js
+++ b/shared/helpers/clusterHelper.js
@@ -27,7 +27,7 @@ const getAllBuckets = async ({ cluster }) => {
 
 /**
  *
- * @param {{bucketName: string, cluster: Cluster}} param
+ * @param {{bucketName: string, cluster: Cluster}} param0
  * @returns {Promise<Bucket>}
  */
 const createNewBucket = async ({ bucketName, cluster }) => {
@@ -37,7 +37,7 @@ const createNewBucket = async ({ bucketName, cluster }) => {
 };
 
 /**
- * @param {{ cluster: Cluster; selectedBucket: string }} selectedBucket
+ * @param {{ cluster: Cluster; selectedBucket: string }} param0
  * @returns {Promise<Bucket[]>}
  */
 const getBucketsForReverse = async ({ cluster, selectedBucket }) => {
@@ -135,7 +135,7 @@ const getErrorMessage = ({ error }) => {
 		case COUCHBASE_ERROR_CODE.inferMethodIsNotSupport:
 			return 'Infer method is not supported.';
 		case COUCHBASE_ERROR_CODE.userDoesNotHaveAccessToPrivilegeCluster:
-			return 'User doesn`t have credentials for privileged cluster.';
+			return "User doesn't have credentials for privileged cluster.";
 		default:
 			return error?.cause?.first_error_message || error?.message || '';
 	}

--- a/shared/helpers/logHelper.js
+++ b/shared/helpers/logHelper.js
@@ -5,7 +5,7 @@
 
 const os = require('os');
 const packageFile = require('../../package.json');
-const { COUCHBASE_ERROR_CODE } = require('../constants');
+const { COUCHBASE_ERROR_CODE, ERROR_SIMPLE_TYPE } = require('../constants');
 
 const getPluginVersion = () => packageFile.version;
 
@@ -49,6 +49,18 @@ const toTime = number => {
 	return Math.floor(number / 3600) + ':' + prefixZero(parseInt((number / 3600 - Math.floor(number / 3600)) * 60));
 };
 
+const prettifyMessage = ({ error = {} }) => {
+	if (error.cause?.first_error_message) {
+		const [reason, context] = error.cause.first_error_message.split(' - cause: ');
+		if (!reason || !context) {
+			return error.cause.first_error_message;
+		}
+		return `${reason.trim()}:\n${context.trim()}`;
+	}
+
+	return error.cause?.message || error.message;
+};
+
 /**
  * @param {{ title: string; logger: AppLogger; hiddenKeys: string[] }} param0
  * @returns {Logger}
@@ -78,10 +90,10 @@ const createError = error => {
 		};
 	}
 
-	return {
-		type: error?.cause?.code === COUCHBASE_ERROR_CODE.authorizationFailure ? 'simpleError' : '',
-		message: error?.cause?.first_error_message || error.cause?.message || error.message,
-	};
+	const type = error?.cause?.code === COUCHBASE_ERROR_CODE.authorizationFailure ? ERROR_SIMPLE_TYPE : error.type;
+	const message = prettifyMessage({ error });
+
+	return { type, message };
 };
 
 const logHelper = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9245" title="HCK-9245" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9245</a>  [CouchbaseV7] Incorrect handle of INSERT with the same key statement (failed but shows success) - Try to use Upsert instead to avoid errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* use `UPSERT` clause by default when inserting documents
* improved error handling for "already exists" cases for scopes/collections/indexes
* skip `SECONDARY` index from final script if it doesn't contain selected keys