### PR TITLE
Ensure unmanaged (undefined) statements like insert don't break the parsing or the RE process

### DIFF
--- a/reverse_engineering/helpers/parserHelper.js
+++ b/reverse_engineering/helpers/parserHelper.js
@@ -36,14 +36,14 @@ const parseN1qlStatements = ({ statements }) => {
  * @returns {ParsedResult}
  */
 const mapParsedResult = ({ result, statements }) => {
-	const scopes = result.flatMap(({ scopes }) => scopes);
-	const collections = result.flatMap(({ collections }) => collections);
+	const scopes = result.flatMap(({ scopes }) => scopes).filter(Boolean);
+	const collections = result.flatMap(({ collections }) => collections).filter(Boolean);
 	const indexes = result.flatMap(({ indexes }) => indexes);
 
 	return {
 		scopes,
 		collections,
-		indexes: mapIndexes({ indexes, statements }),
+		indexes: mapIndexes({ indexes, statements }).filter(Boolean),
 	};
 };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9861" title="HCK-9861" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9861</a>  [Couchbase v7][RE from .n1ql] Impossible to reverse documents previously forwarded by Hackolade
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Fixes https://hackolade.atlassian.net/browse/HCK-9861

## Technical details

The parser returns undefined elements when unmanaged statements are detected in the n1ql file, this change makes the re process tolerant to this case.